### PR TITLE
fix 'is empty'/'not empty' operator should not generate 'value' xml e…

### DIFF
--- a/KoS.Apps.SharePoint.SmartCAML/KoS.Apps.SharePoint.SmartCAML.Editor/Builder/QueryFilters/EmptyQueryFilterController.cs
+++ b/KoS.Apps.SharePoint.SmartCAML/KoS.Apps.SharePoint.SmartCAML.Editor/Builder/QueryFilters/EmptyQueryFilterController.cs
@@ -19,7 +19,7 @@ namespace KoS.Apps.SharePoint.SmartCAML.Editor.Builder.QueryFilters
 
         public override string GetValue()
         {
-            return string.Empty;
+            return null;
         }
     }
 }

--- a/KoS.Apps.SharePoint.SmartCAML/changelog.md
+++ b/KoS.Apps.SharePoint.SmartCAML/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v. 2.3
+##### Fix
++ 'is empty'/'not empty' operator should not generate 'value' xml element
+
 ### v. 2.2
 ##### Update
 + load lookup values in paging


### PR DESCRIPTION
'is empty'/'not empty' generate wrong caml query. should not add 'value' node